### PR TITLE
Enhanced GitHub->Phabricator Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,36 @@ Github to Phabricator migration tool
 ---
 
 # Requirements
-You will need python (of course) and a version of phabricator-python that supports the new token-based authentication of Phabricator. 
-Until it is merged upstream, you can use this version instead : https://github.com/gnoronha/python-phabricator/commits/new-style-auth
+You will need python, python-phabricator, and python-mysqld.
 You will also need to have 'curl' installed.
-For better results, you should have local access to the phabricator installation as well as database access, but it is not mandatory.
+You will need local access to the phabricator installation as well as database access.
 
 # Fetching from github
-This tool has two parts, the first is what fetches all of data from github,
-you can configure it in github_issues.py by setting the username, api token (that you generate in settings->personal access token), the project's org and repository name.
+This tool has three parts, the first is what fetches all of data from github,
+you can configure it in ./config.py by setting the username, api token (that you generate in settings->personal access token), the project's org and repository name.
 You can also set a minimum and maximum issue id to fetch for the migration. 
 The data that gets downloaded from github is cached, so you must create a cache directory before use. If you want to refresh the issues, simply delete its content.
 The script uses the external command 'curl' to fetch all the data, so make sure curl is installed. You can run ./github_issues.py to get it to fetch the issues and comments and print out the title and id of all the issues it found.
 
+# Preparing Phabricator
+The second part creates a bunch of users based on members of your github organization, so the migration can preserve as much audit history as possible.
+You must provide a mapping of github username to your organizations username and real name (see user_map.csv.ex.)
+Important settings in ./config.py are (CREATE_ACCOUNTS and ACCOUNT_EMAIL_DOMAIN)
+*NOTE:* Phabricator does not provide an API endpoint for creating users, one is included in contrib/phabricator_extensions/.
+Your migration user must be a phabricator administrator to hit this endpoint.
 
 # Importing into Phabricator
 The second part is what uploads the data to Phabricator. It can be configured in wmfphablib/config.py file. It will need a dedicated user for the migration (by default "github-migration"), so you must create such a user (add -> User Account) and set it as a bot.
 You will then need to generate a conduit API token for that user, by accessing the user's profile (you can search for the user github-migration, then Edit settings, then Conduit API token).
-Once you generate the token, you can set the phabricator URL, install path, databaser user/password and the Conduit token in the config.py file.
-
-# Remote vs. Local
-You can import into Phabricator either with local access to the phabricator server and access to its database, or by using only the remote API. Using the remote API will not allow you to preserve author and timestamp of issues and their comments (But that information is still retained as part of the description or comment itself).
-If you do not have access to the Phabricator database, you can set the `have_db_access` to `False` in the config.py file.
-
-Access to the phabricator database is required in order to force the task IDs to match the github issue id, as well as to be able to set the author and date of the task and comments. If database access is disabled, only the Conduit API will be used.
-Note that forcing the phabricator task id to match github issue id will only be possible if there are no tasks in Phabricator. This feature can be disabled or enabled with the `force_ids` configuration variable.
+Once you generate the token, you can set the phabricator URL, install path, databaser user/password and the Conduit token in the wmfphablib/config.py file.
 Setting the phabricator_path is only necessary if you want to delete the existing tasks before importing. If `delete_existing_issues` is set to `False`, then the phabricator_path and access to the server is not required. Deleting existing tasks will only delete the tasks for the selected project, to avoid any potential mistakes.
+
+# Translate Labels
+There is a complex system of "translations" that can happen during the migration.
+This allows you to use github labels and milestones to set Phabricator tasks during
+the migration. set priority, status, custom fields, even add or replace destination
+project tags. It is not well documented, but some examples are provided in the
+wmfphablib/config.py file. It most certainly conatins bugs ;-)
 
 # License
 The wmfphablib code was copied from the wikimedia phabricator tools repository (https://gerrit.wikimedia.org/r/#/admin/projects/phabricator/tools) and modified to suit our needs.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+
+import re
+
+## GitHub Settings:
+
+USERNAME="github username"
+TOKEN="github access token"
+USER="organization"
+PROJECT="repository"
+CACHE_DIR="cache/"
+BASE_URL="https://api.github.com"
+
+# Limit Issues to Migrate (Ignored unless both are set.)
+MIN_ID=None
+MAX_ID=None
+
+#github_members.py
+CREATE_ACCOUNTS=True
+ACCOUNT_EMAIL_DOMAIN="domain.com"
+
+## Strip the following patterns from issue descriptions
+CLEAN_DESCRIPTION_REGEXES=[
+    re.compile("<!--.*?huboard.*?-->\n?", re.MULTILINE | re.DOTALL),
+]
+
+## STATIC_FIELDS is not used in an automated way, but left here as an example
+## of something to put in the Maniphest custom field definitions.
+
+STATIC_FIELDS="""
+    "com.example.task_type": {
+        "name": "Type",
+        "description": "Task Type",
+        "type": "select",
+        "options": {
+            "com.example.task_type:none": "",
+            "com.example.task_type:bug": "Bug",
+            "com.example.task_type:enhancement": "Enhancement",
+            "com.example.task_type:feature": "Feature"
+        },
+        "search": true
+    },
+    "com.example.release": {
+       "name": "Release",
+       "description" : "release version",
+       "type": "select",
+       "options": {
+           "com.example.release:none": "",
+           "com.example.release:1.0.0": "1.0.0",
+           "com.example.release:1.0.1": "1.0.1",
+           "com.example.release:1.0.2": "1.0.2",
+           "com.example.release:1.0.3": "1.0.3",
+           "com.example.release:1.0.4": "1.0.4",
+           "com.example.release:1.1.0": "1.1.0",
+           "com.example.release:1.2.0": "1.2.0"
+       },
+       "search": true
+    },
+    "com.example.team" : {
+       "name": "Team",
+       "description": "Responsible development team",
+       "type": "select",
+       "options": {
+          "com.example.team:none": "",
+          "com.example.team:apps": "Apps",
+          "com.example.team:core": "Core",
+          "com.example.team:services": "Services"
+       },
+       "search": true
+    },
+    "com.example.component" : {
+       "name": "Component",
+       "description": "Software Component",
+       "type": "select",
+       "options": {
+          "com.example.component:none": "",
+          "com.example.component:audio_video": "Audio / Video",
+          "com.example.component:build_infrastructure": "Build Infrastructure",
+          "com.example.component:content": "Content",
+          "com.example.component:core_platform": "Core Platform",
+          "com.example.component:desktop": "Desktop",
+          "com.example.component:dev_tools": "Dev Tools",
+          "com.example.component:file_manager": "File Manager",
+          "com.example.component:games": "Games",
+          "com.example.component:help_center": "Help Center",
+          "com.example.component:initial_setup": "Initial Setup",
+          "com.example.component:localization": "Localization",
+          "com.example.component:peripherals": "Peripherals",
+          "com.example.component:power_boot": "Power / Boot",
+       },
+       "search": true
+    },
+    "com.example.hw_product": {
+        "name": "HW Product",
+        "description": "Specific hardware model(s) (if applicable)",
+        "type": "text",
+        "search": true
+    }
+"""

--- a/contrib/phabricator_extensions/README.md
+++ b/contrib/phabricator_extensions/README.md
@@ -1,0 +1,1 @@
+Install these php files to phabricator/src/extensions/

--- a/contrib/phabricator_extensions/UserCreateAPIMethod.php
+++ b/contrib/phabricator_extensions/UserCreateAPIMethod.php
@@ -1,0 +1,97 @@
+<?php
+
+final class UserEnableConduitAPIMethod extends UserConduitAPIMethod {
+
+  public function getAPIMethodName() {
+    return 'user.create';
+  }
+
+  public function getMethodDescription() {
+    return pht('Create users (admin only).');
+  }
+
+  protected function defineParamTypes() {
+    return array(
+      'username' => 'required string<username>',
+      'realname' => 'required string<realname>',
+      'email'    => 'required string<email>',
+      'password' => 'required string<password>',
+    );
+  }
+
+  protected function defineReturnType() {
+    return 'string<phid>';
+  }
+
+  protected function defineErrorTypes() {
+    return array(
+      'ERR-PERMISSIONS' => pht('Only admins can call this method.'),
+      'ERR-INVALID-USERNAME' => pht('Invalid username'),
+      'ERR-USER-EXISTS' => pht('User already exists'),
+      'ERR-DUPLICATE-EMAIL' => pht('Duplicate email address'),
+    );
+  }
+
+  protected function execute(ConduitAPIRequest $request) {
+    $actor = $request->getUser();
+    if (!$actor->getIsAdmin()) {
+      throw new ConduitException('ERR-PERMISSIONS');
+    }
+
+    $username = $request->getValue('username');
+    $realname = $request->getValue('realname');
+    $create_email = $request->getValue('email');
+    $password = $request->getValue('password');
+
+    if (!PhabricatorUser::validateUsername($username)) {
+      throw new ConduitException('ERR-INVALID-USERNAME');
+    }
+
+    if (!PhabricatorUserEmail::isAllowedAddress($create_email)) {
+      throw new ConduitException('ERR-INVALID-EMAIL');
+    }
+
+    $users = id(new PhabricatorPeopleQuery())
+      ->setViewer($request->getUser())
+      ->withUsernames([$username])
+      ->execute();
+
+    if (count($users) != 0) {
+      throw new ConduitException('ERR-USER-EXISTS');
+    }
+
+    # Verify Unique email
+    $duplicate = id(new PhabricatorUserEmail())->loadOneWhere(
+      'address = %s',
+      $create_email);
+    if ($duplicate) {
+      throw new ConduitException('ERR-DUPLICATE-EMAIL');
+    }
+
+    $user = new PhabricatorUser();
+    $user->setUsername($username);
+    $user->setRealName($realname);
+
+    $user->openTransaction();
+
+      $editor = new PhabricatorUserEditor();
+      $editor->setActor($actor);
+
+      $email = id(new PhabricatorUserEmail())
+        ->setAddress($create_email)
+        ->setIsVerified(1);
+
+      $user->setIsApproved(1);
+
+      $editor->createNewUser($user, $email);
+
+      $envelope = new PhutilOpaqueEnvelope($password);
+      $editor->changePassword($user, $envelope);
+
+    $user->saveTransaction();
+
+    return $user->getPHID();
+
+  }
+
+}

--- a/github_cache.py
+++ b/github_cache.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+
+import os
+import subprocess
+import time
+
+from config import *
+
+def fetch_cached_json(suffix):
+    path = CACHE_DIR + suffix.replace("/", "_")
+    if os.path.exists(path):
+        with open(path, 'r') as f:
+            return f.read()
+    return None
+
+def write_cached_json(suffix, data):
+    path = CACHE_DIR + suffix.replace("/", "_")
+    with open(path, 'w') as f:
+        f.write(data)
+
+def rate_limited(headers):
+    limited=False
+    reset_time=None
+    for line in headers:
+        if line.find(": ") == -1:
+            continue
+        (h, v) = line.split(": ")
+        if h == "X-RateLimit-Remaining":
+            try:
+                remaining = int(v)
+            except ValueError:
+                continue
+            if remaining < 1:
+                limited=True
+        if h == "X-RateLimit-Reset":
+            try:
+                reset_time = int(v)
+            except ValueError:
+                continue
+    if limited:
+        print "Warning: Rate Limit Reached"
+        print " X-RateLimit-Reset: %d"%(reset_time)
+        now = int(time.time())
+        print " Current Time: %d"%(now)
+        secs=reset_time-now+1
+        print " Sleep Seconds: %d"%(secs)
+        if secs > 0:
+            time.sleep(secs)
+            return True
+
+def fetch_json(suffix):
+    cached = fetch_cached_json(suffix)
+    if cached is None:
+        url = BASE_URL + suffix
+
+        process = subprocess.Popen(['curl', '-i', '-s', '-u', USERNAME + ":" + TOKEN, url],
+                               stdout=subprocess.PIPE)
+        result = process.communicate()[0]
+        write_cached_json(suffix, result)
+    else:
+        result = cached
+    (headers, payload) = result.split("\r\n\r\n", 1)
+    if rate_limited(headers.split("\r\n")):
+        return fetch_json(suffix)
+    return (headers, payload)

--- a/github_members.py
+++ b/github_members.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+import json
+import random
+import string
+from config import *
+from github_cache import *
+from wmfphablib.phabapi import phabapi
+
+from lib_user_map import *
+
+class Member(object):
+    def __init__(self, github_dict):
+        self.json = github_dict
+        self.login = self.json['login']
+        if self.json['name']:
+            self.name = self.json['name']
+        else:
+            self.name = ""
+        if self.json['name']:
+            self.email = self.json['email']
+        else:
+            self.email = ""
+
+def FetchGithubMembers():
+    page = 1
+    num_pages = 1
+
+    members = []
+    github_members = []
+
+    while page <= num_pages:
+        (headers, members_json) = fetch_json("/orgs/%s/members?per_page=100&page=%d" % (USER,page))
+        page = page + 1
+        members.extend(json.loads(members_json))
+        headers = headers.split('\r\n')
+        for header in headers[1:]:
+            (key, value) = header.split(":", 1)
+            if key == "Link":
+                try:
+                    value.index('rel="next"')
+                    num_pages = page
+                except:
+                    pass
+                break
+
+    for i in members:
+        (headers, member_json) = fetch_json("/users/%s" % (i["login"]))
+        member = Member(json.loads(member_json))
+        github_members.append(member)
+
+    return sorted(github_members)
+
+def gen_password():
+    chars = string.letters + string.digits
+    newpasswd = ""
+    for i in range(8):
+        newpasswd = newpasswd + random.choice(chars)
+    return newpasswd
+
+if __name__ == '__main__':
+    from wmfphablib import phabapi
+    from phabricator import APIError
+    api = phabapi.phabapi()
+    members = FetchGithubMembers()
+    for member in members:
+        print "#%s" % (member.login)
+        login = member.login.lower()
+        user = tr_user(member.login)
+        name = tr_user_name(member.login)
+        if CREATE_ACCOUNTS != True:
+            continue
+        password=gen_password()
+        if user != None:
+            email = "%s@%s"%(user,ACCOUNT_EMAIL_DOMAIN)
+        else:
+            email = "no-reply-github-user-%s@%s"%(login,ACCOUNT_EMAIL_DOMAIN)
+        if name == None:
+            name = login
+        try:
+            api.create_user(login, name, email, password)
+        except APIError, e:
+            print "Warning: Failed to create user %s: %s"%(login, e)
+        else:
+            print "%s,%s"%(login, password)

--- a/github_to_phab.py
+++ b/github_to_phab.py
@@ -1,16 +1,47 @@
 #!/usr/bin/python
 
+import re
+import string
 import sys
+import urllib2
 from github_issues import FetchGithubIssues
 from wmfphablib import phabdb
 from wmfphablib import phabapi
 from wmfphablib import util
 from wmfphablib import config
 
+from config import *
 
 github_issues = FetchGithubIssues()
 api = phabapi.phabapi()
 project_phid = api.get_project_phid(config.project_name)
+re_attachment=re.compile("\!?\[(.*?)\]\((.*?githubusercontent.*?)\)")
+
+def lower_snake_caseify(s):
+    return "_".join(re.sub(r'\W+', ' ', s.lower()).split(None))
+
+def migrate_attachments(comment):
+    # Migrate Attachments
+    m_attachment = re_attachment.search(comment)
+    while m_attachment != None:
+        s_pos = m_attachment.start(0)
+        e_pos = m_attachment.end(0)
+        print " => Attachment Found: \"%s\"" % (comment[s_pos:e_pos])
+        title = m_attachment.group(1)
+        link = m_attachment.group(2)
+        try:
+            data = urllib2.urlopen (link)
+        except urllib2.HTTPError, e:
+            comment = comment[0:s_pos] + "** FAILED TO MIGRATE <%s|%s> **"%(title, link) + comment[e_pos:-1]
+        else:
+            try:
+                upload = api.upload_file(title, data.read(), "")
+            except:
+                comment = comment[0:s_pos] + "** FAILED TO MIGRATE <%s|%s> **"%(title, link) + comment[e_pos:-1]
+            else:
+                comment = comment[0:s_pos] + "{%s}"%upload["objectName"] + comment[e_pos:-1]
+        m_attachment = re_attachment.search(comment)
+    return comment
 
 if project_phid is None:
     print "Could not find the project '%s' in Phabricator" % config.project_name
@@ -33,14 +64,22 @@ if config.force_ids and len(phabdb.get_task_list()) > 0:
     sys.exit(-1)
 
 for issue in github_issues:
-    print "Creating issue %d" % issue.id
+    print "Migrating issue %d" % issue.id
     author_phid = api.get_phid_by_username(issue.author)
     assignee_phid = None if issue.assignee is None else api.get_phid_by_username(issue.assignee)
-    description = "= Task migrated from github issue #%d which was available at %s =\n\n%s" % (issue.id, issue.url, issue.description)
+    if issue.description == None:
+        clean_issue_description = ""
+    else:
+        clean_issue_description = issue.description
+    for re_obj in CLEAN_DESCRIPTION_REGEXES:
+        clean_issue_description = re_obj.sub("",clean_issue_description)
+    description = "= Task migrated from github issue #%d which was available at %s =\n\n%s" % (issue.id, issue.url, clean_issue_description)
     if config.have_db_access is False or author_phid is None:
         description = "> Issue originally made by **%s** on //%s//\n\n%s" % (issue.author, issue.created_at, description)
+    description = migrate_attachments(description)
     new_task = api.task_create(issue.title, description, issue.id, 90, assignee_phid, [project_phid])
     phid = new_task['phid']
+    print " => Phabricator Task: " + phid
     if config.force_ids:
         phabdb.set_task_id(issue.id, phid)
         id = issue.id
@@ -59,11 +98,142 @@ for issue in github_issues:
             if issue.closed_at:
                 tphid = phabdb.last_state_change(phid)
                 phabdb.set_transaction_time(tphid, issue.closed_at.strftime("%s"))
+
+    if config.static_custom_fields != None:
+        for field in config.static_custom_fields.keys():
+            api.set_custom_field(id, field, config.static_custom_fields[field])
+
+    for translation in config.translations:
+
+        #INIT
+        hits=[]
+
+        #SOURCE
+        if translation['source_type'] == "MILESTONE" and issue.milestone != None:
+            match = translation['match_object'].search(issue.milestone)
+            if match:
+                hits.append(match)
+
+        if translation['source_type'] == "LABEL":
+            for ilabel in issue.labels:
+                match = translation['match_object'].search(ilabel)
+                if match:
+                    hits.append(match)
+
+        if translation['source_type'] == "MULTI_LABEL":
+            overall_match = True
+            for match_object in translation['match_object']:
+                match_found = False
+                for ilabel in issue.labels:
+                    match = match_object.search(ilabel)
+                    if match:
+                        match_found = True
+                if not match_found:
+                    overall_match = False
+                    break
+            if overall_match:
+                hits.append(False)
+
+        if translation['source_type'] == "DESCRIPTION":
+            if issue.description == None:
+                continue
+            match = translation['match_object'].search(issue.description)
+            if match:
+                hits.append(match)
+
+        if translation['source_type'] == "TITLE":
+            if issue.title == None:
+                continue
+            match = translation['match_object'].search(issue.title)
+            if match:
+                hits.append(match)
+
+        if translation['source_type'] == "PHAB_COMPONENT":
+            aux_field_name = "std:maniphest:com.example.component"
+            task_info = api.get_task_info(id)
+            if task_info['auxiliary'].has_key(aux_field_name) and task_info['auxiliary'][aux_field_name] != None:
+                match = translation['match_object'].search(task_info['auxiliary'][aux_field_name])
+                if match:
+                    hits.append(match)
+
+
+        #DEST
+        for match in hits:
+            if match and len(match.groups()) > 0:
+                source_group=match.group(1)
+            else:
+                source_group=None
+
+            if translation['source_type'] == "MULTI_LABEL":
+                match_objects=""
+                for m in translation['match_object']:
+                        match_objects += m.pattern + ", "
+                match_objects=match_objects[0:-2]
+                print " => Translation [MULTI_LABEL (%s)=>%s (%s, %s)]"%(match_objects,translation['destination_type'], str(translation['destination_opts']),source_group)
+            else:
+                print " => Translation [%s (%s)=>%s (%s, %s)]"%(translation['source_type'], translation['match_object'].pattern,translation['destination_type'], str(translation['destination_opts']),source_group)
+
+            if translation['destination_type'] == "CUSTOM_FIELD":
+                ( field_name, field_value ) = translation['destination_opts']
+                if source_group != None:
+                    value = field_value % (source_group)
+                else:
+                    value = field_value
+                api.set_custom_field(id, field_name, value)
+
+            if translation['destination_type'] == "APPEND_CUSTOM_TEXT_FIELD":
+                ( field_name, field_value ) = translation['destination_opts']
+                if source_group != None:
+                    value = field_value % (source_group)
+                else:
+                    value = field_value
+                task_info = api.get_task_info(id)
+                aux_field_name="std:maniphest:%s"%(field_name)
+                if task_info['auxiliary'].has_key(aux_field_name) and task_info['auxiliary'][aux_field_name] != None:
+                        value = task_info['auxiliary'][aux_field_name] + ", " + value
+                api.set_custom_field(id, field_name, value)
+
+            if translation['destination_type'] == "SET_PROJECT":
+                new_project = translation['destination_opts']
+                new_project_phid = api.get_project_phid(new_project)
+                api.change_project(id, [new_project_phid])
+
+            if translation['destination_type'] == "ADD_PROJECT":
+                new_project = translation['destination_opts']
+                new_project_phid = api.get_project_phid(new_project)
+                projects=set(api.get_task_info(id)['projectPHIDs'])
+                new_projects=list(projects.union([new_project_phid]))
+                api.change_project(id, new_projects)
+
+            if translation['destination_type'] == "COMPONENT":
+                field_name = translation['destination_opts']
+                component_name = field_name + ":" + lower_snake_caseify(source_group)
+                api.set_custom_field(id, field_name, component_name)
+
+            if translation['destination_type'] == "STATUS":
+                field_value = translation['destination_opts']
+                api.set_status(id, field_value)
+
+            if translation['destination_type'] == "PRIORITY":
+                field_value = translation['destination_opts']
+                api.set_priority(id, field_value)
+
+            if translation['destination_type'] == "ADD_COMMENT":
+                field_value = translation['destination_opts']
+                if source_group != None:
+                    value = field_value % (source_group)
+                else:
+                    value = field_value
+                api.task_comment(id, value)
+
+
     for (author, date, comment) in issue.comments:
         print "Adding comment from %s" % author
         author_phid = api.get_phid_by_username(author)
         if author_phid is None or config.have_db_access is False:
             comment = "> Comment originaly made by **%s** on //%s//\n\n%s" % (author, date, comment)
+        comment = migrate_attachments(comment)
+
         api.task_comment(id, comment)
         if config.have_db_access:
             tphid = phabdb.last_comment(phid)

--- a/lib_user_map.py
+++ b/lib_user_map.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+import csv
+user_map = {}
+with open('user_map.csv', 'rb') as csvfile:
+    reader = csv.reader(csvfile)
+    for row in reader:
+        github_login=row[0].strip()
+        google_account=row[1].strip()
+        real_name=row[2].strip()
+        if len(row) >= 3 and github_login != "" and google_account != "":
+            user_map[github_login]={
+                'account': google_account,
+                'name': real_name,
+            }
+
+def tr_user(user):
+    if user_map.has_key(user) and user_map[user]['account'] != "":
+        return user_map[user]['account']
+    else:
+        return None
+
+def tr_user_name(user):
+    if user_map.has_key(user):
+        return user_map[user]['name']
+    else:
+        return None
+

--- a/user_map.csv.ex
+++ b/user_map.csv.ex
@@ -1,0 +1,3 @@
+github_user,account_name,Real Name
+github_user,account_name,Real Name
+github_user,account_name,Real Name

--- a/wmfphablib/config.py
+++ b/wmfphablib/config.py
@@ -1,13 +1,128 @@
 #!/usr/bin/env python
-dbhost = "localhost"
-phuser_user = "root"
-phuser_passwd = "password"
+
+#Phabricator API Access Settings:
 phab_token = "api-token"
 phab_host = "https://phabricator.example.com/api/"
 phabricator_path = "/srv/phabricator"
-project_name = "project-name"
-migration_user = "github-migration"
-delete_existing_issues = False
-force_ids = False
-have_db_access = False
 
+#phabricator DB access Settings:
+have_db_access = True #Disabling this setting is untested and will likely break lots of stuff now...
+force_ids = False
+delete_existing_issues = False
+dbhost = "localhost"
+phuser_user = "root"
+phuser_passwd = "password"
+
+#Migration Settings:
+migration_user = "github-migration" #Phabricator Migration User
+project_name = "project-name" #Default Project to add tasks to
+static_custom_fields = { "com.example.team": "com.example.team:core" } #Default cutom fields to set on all tasks
+file_upload_timeout = 300
+
+##
+## Translations
+##   use source data from github to effect the task import. See examples
+## below. translations are run on every task in order. later translations
+## can override what earlier translations have done.
+##
+##
+
+import re
+translations = [
+  {
+    "source_type":      "MILESTONE",
+    "match_object":     re.compile("^Version-(\d+\.\d+\.\d+)"),
+    "destination_type": "CUSTOM_FIELD",
+    "destination_opts": [ "com.example.release", "com.example.release:%s" ]
+  },
+  {
+    "source_type":      "MILESTONE",
+    "match_object":     re.compile("^(?:Closed )?IT Tasks"),
+    "destination_type": "SET_PROJECT",
+    "destination_opts": "IT",
+  },
+  {
+    "source_type":      "MILESTONE",
+    "match_object":     re.compile("^(?:Closed )?IT Tasks"),
+    "destination_type": "CUSTOM_FIELD",
+    "destination_opts": [ "com.example.team", "com.example.team:none" ],
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Critical$"),
+    "destination_type": "PRIORITY",
+    "destination_opts": 100
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^High Priority$"),
+    "destination_type": "PRIORITY",
+    "destination_opts": 80
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Medium Priority$"),
+    "destination_type": "PRIORITY",
+    "destination_opts": 50
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Low Priority$"),
+    "destination_type": "PRIORITY",
+    "destination_opts": 25
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Unprocessed$"),
+    "destination_type": "PRIORITY",
+    "destination_opts": 90
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Cmpnt:\w*(.+)$"),
+    "destination_type": "COMPONENT",
+    "destination_opts": "com.example.component",
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Product:\w*(.+)$"),
+    "destination_type": "APPEND_CUSTOM_TEXT_FIELD",
+    "destination_opts": [ "com.example.hw_product", "%s" ],
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^(:?Duplicate|Invalid)$"),
+    "destination_type": "STATUS",
+    "destination_opts": "invalid",
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Won't fix$"),
+    "destination_type": "STATUS",
+    "destination_opts": "wontfix",
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Bug$"),
+    "destination_type": "CUSTOM_FIELD",
+    "destination_opts": [ "com.example.task_type", "com.example.task_type:bug" ],
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Enhancement$"),
+    "destination_type": "CUSTOM_FIELD",
+    "destination_opts": [ "com.example.task_type", "com.example.task_type:enhancement" ],
+  },
+  {
+    "source_type":      "LABEL",
+    "match_object":     re.compile("^Blocked: Product$"),
+    "destination_type": "ADD_PROJECT",
+    "destination_opts": "Product",
+  },
+  {
+    "source_type":      "PHAB_COMPONENT",
+    "match_object":     re.compile(":(?:database|infrastructure)$"),
+    "destination_type": "CUSTOM_FIELD",
+    "destination_opts": [ "com.example.team", "com.example.team:services" ],
+  },
+]

--- a/wmfphablib/phabapi.py
+++ b/wmfphablib/phabapi.py
@@ -1,8 +1,11 @@
 import base64
 import config
 import phabricator
+import traceback
 from phabricator import Phabricator
+from phabricator import Resource
 import phabdb
+import time
 from util import log
 from util import vlog
 from util import errorlog as elog
@@ -13,134 +16,146 @@ class phabapi:
     def __init__(self):
         self.con = Phabricator(host=config.phab_host, token=config.phab_token)
 
-    def blog_update(self, botname, title, body):
-        blogphid = phabdb.get_bot_blog(botname)
-        if blogphid is None:
-            elog('blogphid is none')
-            return
-        return self.con.phame.createpost(blogPHID=blogphid,
-                                         body=body,
-                                         title=title,
-                                         phameTitle=title)
-
-    def sync_assigned(self, userphid, id, prepend):
-        refs = phabdb.reference_ticket('%s%s' % (prepend, id))
-        if not refs:
-            log('reference ticket not found for %s' % ('%s%s' % (prepend, id),))
-            return
-        current = self.con.maniphest.query(phids=[refs[0]])
-        if current[current.keys()[0]]['ownerPHID']:
-            log('current owner found for => %s' % (str(id),))
-            return current
-        log('assigning T%s to %s' % (str(id), userphid))
-        return phabdb.set_issue_assigned(refs[0], userphid)
-
-    def synced_authored(self, phid, id, ref):
-        refs = phabdb.reference_ticket('%s%s' % (ref, id))
-        if not refs:
-            log('reference ticket not found for %s' % ('%s%s' % (ref, id),))
-            return
-        log('reference ticket found for %s' % ('%s%s' % (ref, id),))
-        newid = self.ticket_id_by_phid(refs[0])
-        log("Updating author for %s to %s" % (refs, phid))
-        phabdb.set_task_author(phid, newid)
-
-        descript = phabdb.get_task_description(refs[0])
-        try:
-            clean_description = descript.split('**Description:**\n', 1)[1]
-            phabdb.set_task_description(refs[0], clean_description)
-        except:
-            phabdb.set_task_description(refs[0], descript)
+    def call_method(self, method, endpoint, args):
+        retries = 2
+        out = None
+        __method = Resource(api=self.con, method=method, endpoint=endpoint)
+        while out == None and retries > 0:
+            try:
+                out = __method(**args)
+            except Exception, e:
+                print "Warning: API Call to %s.%s with args %s failed:\n%s" % (method, endpoint, args, e)
+                traceback.print_exc()
+                time.sleep(1)
+                retries = retries - 1
+        if out == None:
+            raise Exception("API Call to %s.%s failed 3 times, giving up..."%(method, endpoint))
+        return out
 
     def task_comment(self, task, msg):
-        out = self.con.maniphest.update(id=task, comments=msg)
+        out = self.call_method("maniphest", "update", {'id': task, 'comments': msg})
         return out
 
     def set_status(self, task, status):
-        out = self.con.maniphest.update(id=task, status=status)
+        out = self.call_method("maniphest", "update", {'id': task, 'status': status})
+        return out
+
+    def set_priority(self, task, priority):
+        out = self.call_method("maniphest", "update", {'id': task, 'priority': priority})
+        return out
+
+    def set_custom_field(self, task, field, value):
+        out = self.call_method("maniphest", "update", {'id': task, 'auxiliary': {"std:maniphest:%s"%(field): value}})
+        return out
+
+    def change_project(self, task, projects=[]):
+        out = self.call_method("maniphest", "update", {'id': task, 'projectPHIDs': projects})
+        return out
+
+    def get_task_info(self, task):
+        out = self.call_method("maniphest", "info", {'task_id': int(task)})
         return out
 
     def task_create(self, title, desc, id, priority, ownerPhid=None, projects=[]):
-        return self.con.maniphest.createtask(title=title,
-                                        description="%s" % desc,
-                                        projectPHIDs=projects,
-                                        priority=priority,
-                                        ownerPHID=ownerPhid,
-                                        auxiliary={"std:maniphest:external_reference":"%s" % (id,)})
+        return self.call_method( "maniphest", "createtask",
+            {
+                'title': title,
+                'description': desc,
+                'projectPHIDs': projects,
+                'priority': priority,
+                'ownerPHID': ownerPhid,
+                'auxiliary': {"std:maniphest:external_reference":"%s" % (id,)}
+            })
 
     def get_project_phid(self, name):
-        result = self.con.project.query(names=[name])
+        result = self.call_method("project", "query", {'names': [name]})
         if result:
             return result['data'].keys()[0]
         return None
 
     def get_phid_by_username(self, username):
-        result = self.con.user.query(usernames=[username])
+        result = self.call_method("user", "query", {'usernames': [username]})
         if len(result.response):
             return result[0]['phid']
         return None
 
-if config.have_db_access:
-    def ensure_project(self, project_name,
-                             pmembers=[],
-                             view='public',
-                             edit='public'):
-        """make sure project exists
-        :param project_name: str
-        :param pmembers: list
-        :param view: str
-        :param edit str"""
-        existing_proj = phabdb.get_project_phid(project_name)
-        #print "EXISTING PROJ: ", existing_proj
-        #print "EXISTING PROJ TYPE: ", type(existing_proj)
-        #existing_proj = self.con.project.query(names=[project_name])
-        if not existing_proj:
-            log('need to create project(s) ' + project_name)
-            try:
-                new_proj = self.con.project.create(name=project_name, members=pmembers)
-            #XXX: Bug where we have to specify a members array!
-            except phabricator.APIError:
-                pass
-            phid = phabdb.get_project_phid(project_name)
-            if not phid:
-                raise Exception("Project %s does not exist still." % (project_name,))
+    def create_user(self, username, realname, email, password):
+        self.call_method("user", "create", {'username': username, 'realname': realname, 'email': email, 'password': password})
+        # should this return something?
+
+    if config.have_db_access:
+        def ensure_project(self, project_name,
+                                 pmembers=[],
+                                 view='public',
+                                 edit='public'):
+            """make sure project exists
+            :param project_name: str
+            :param pmembers: list
+            :param view: str
+            :param edit str"""
+            existing_proj = phabdb.get_project_phid(project_name)
+            #print "EXISTING PROJ: ", existing_proj
+            #print "EXISTING PROJ TYPE: ", type(existing_proj)
             #existing_proj = self.con.project.query(names=[project_name])
-            #log(str(existing_proj))
-            #phid = existing_proj['data'][existing_proj['data'].keys()[0]]['phid']
-            phabdb.set_project_policy(phid, view, edit)
-        else:
-            phid = existing_proj
-            #phid = existing_proj['data'][existing_proj['data'].keys()[0]]['phid']
-            log(project_name + ' exists')
-        return phid
+            if not existing_proj:
+                log('need to create project(s) ' + project_name)
+                try:
+                    new_proj = self.con.project.create(name=project_name, members=pmembers)
+                #XXX: Bug where we have to specify a members array!
+                except phabricator.APIError:
+                    pass
+                phid = phabdb.get_project_phid(project_name)
+                if not phid:
+                    raise Exception("Project %s does not exist still." % (project_name,))
+                #existing_proj = self.con.project.query(names=[project_name])
+                #log(str(existing_proj))
+                #phid = existing_proj['data'][existing_proj['data'].keys()[0]]['phid']
+                phabdb.set_project_policy(phid, view, edit)
+            else:
+                phid = existing_proj
+                #phid = existing_proj['data'][existing_proj['data'].keys()[0]]['phid']
+                log(project_name + ' exists')
+            return phid
 
-    def upload_file(self, name, data, viewPolicy, dump=False):
+        def upload_file(self, name, data, viewPolicy, dump=False):
 
-        if dump:
-            with open(name, 'wb') as f:
-                f.write(data)
+            if dump:
+                with open(name, 'wb') as f:
+                    f.write(data)
 
-        log("upload policy for %s is %s" % (name, viewPolicy))
-        out = {}
-        self.con.timeout = config.file_upload_timeout
-        encoded = base64.b64encode(data)
-        uploadphid = self.con.file.upload(name=name,
-                                          data_base64=encoded,
-                                          viewPolicy=viewPolicy)
-        out['phid'] = uploadphid
-        log("%s upload response: %s" % (name, uploadphid.response))
-        fileid = phabdb.get_file_id_by_phid(uploadphid.response)
-        out['id'] = int(fileid)
-        out['name'] = name
-        out['objectName'] = "F%s" % (fileid,)
-        log("Created file id: %s" % (fileid,))
-        self.con.timeout = 5
-        return out
+            log("upload policy for %s is %s" % (name, viewPolicy))
+            out = {}
+            self.con.timeout = config.file_upload_timeout
+            chunk_threshold = 8*1024*1024;
+            chunk_size = 4*1024*1024;
+            file_len = len(data)
+            if file_len <= chunk_threshold:
+                encoded = base64.b64encode(data)
+                response = self.call_method("file", "upload", {'name': name, 'data_base64': encoded, 'viewPolicy': viewPolicy})
+                uploadphid = response.response
+                out['phid'] = uploadphid
+            else: # Do chunked upload
+                uploadphid = self.call_method("file", "allocate", {'name': name, 'contentLength': file_len, 'viewPolicy': viewPolicy})['filePHID']
+                cur_pos = 0
+                while cur_pos < file_len:
+                    end_pos = cur_pos + chunk_size
+                    encoded=base64.b64encode(data[cur_pos:end_pos])
+                    self.call_method("file", "uploadchunk", {'filePHID': uploadphid, 'byteStart': cur_pos, 'dataEncoding': "base64", 'data': encoded})
+                    cur_pos = end_pos
+                out['phid'] = uploadphid
+            log("%s upload response: %s" % (name, uploadphid))
+            fileid = phabdb.get_file_id_by_phid(uploadphid)
+            out['id'] = int(fileid)
+            out['name'] = name
+            out['objectName'] = "F%s" % (fileid,)
+            log("Created file id: %s" % (fileid,))
+            self.con.timeout = 5
+            return out
 
-    def ticket_id_by_phid(self, phid):
-         tinfo = self.con.maniphest.query(phids=[phid])
-         if not tinfo:
-             return ''
-         if not tinfo.keys():
-             return ''
-         return tinfo[tinfo.keys()[0]]['id']
+        def ticket_id_by_phid(self, phid):
+             tinfo = self.con.maniphest.query(phids=[phid])
+             if not tinfo:
+                 return ''
+             if not tinfo.keys():
+                 return ''
+             return tinfo[tinfo.keys()[0]]['id']


### PR DESCRIPTION
This patch provides increased functionality that I used in a
complex migration based on your original work. Here are some
feature highlights:
- Handle GitHub API rate-limiting
- Translate Labels (and Milestones) to Phabricator fields
- strip patterns from descriptions
- Github Organization Member migration
- Migrate image attachments
- Fix failure cases talking to phabricator api
- print tracebacks from phabricator api failures

This code worked for me in a final migration, but leaves a lot
to be desired in maintainability and documentation. I've spent
a bit of time to try and write some bare bones documentation, and
update yours where appropriate. I think this code may be useful
for others.

peace out,

"Philip Freeman" freeman@endlessm.com

"Philip Freeman" elektron@halo.nu
